### PR TITLE
Add color and age fields in model Cat

### DIFF
--- a/db/migrate/20160121172838_alter_cats_add_color_and_age.rb
+++ b/db/migrate/20160121172838_alter_cats_add_color_and_age.rb
@@ -1,0 +1,9 @@
+class AlterCatsAddColorAndAge < ActiveRecord::Migration
+  def change
+    add_column :cats, :color, :string
+    add_column :cats, :age, :integer
+    
+    add_index :cats, :color
+    add_index :cats, :age
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160121172333) do
+ActiveRecord::Schema.define(version: 20160121172838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,11 @@ ActiveRecord::Schema.define(version: 20160121172333) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "color"
+    t.integer  "age"
   end
+
+  add_index "cats", ["age"], name: "index_cats_on_age", using: :btree
+  add_index "cats", ["color"], name: "index_cats_on_color", using: :btree
 
 end


### PR DESCRIPTION
Run migration to add color (string) and age (integer) fields in the model Cat. Simply having cat names doesn't quite describe what the cat is like.
